### PR TITLE
Refactor prop types

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ Create development server:
 yarn start
 ```
 
+**It is recommended to have an IDE with an [ESLint](https://github.com/eslint/eslint) plugin.** To run the linter:
+
+```sh
+yarn run lint
+```
+
+To quick-fix warnings:
+
+```sh
+yarn run lint -- --fix
+```
+
 ### iOS
 
 Run an iOS emulator with:

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "moment": "^2.18.1",
     "moment-duration-format": "^1.3.0",
     "normalizr": "^3.2.2",
+    "prop-types": "^15.5.8",
     "qs": "^6.4.0",
     "react": "^15.5.4",
     "react-i18next": "^3.1.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,8 @@
 /* eslint class-methods-use-this: 0 */
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
 import { BackAndroid } from "react-native";
+import PropTypes from "prop-types";
 import { Provider, connect } from "react-redux";
 import { NavigationActions } from "react-navigation";
 import noop from "lodash/noop";

--- a/src/I18n.js
+++ b/src/I18n.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import { I18nextProvider } from "react-i18next";
 import i18next from "i18next";
 

--- a/src/Notifications.js
+++ b/src/Notifications.js
@@ -1,6 +1,7 @@
 /* eslint class-methods-use-this: 0, no-console: 0 */
 
-import { PropTypes, Component } from "react";
+import { Component } from "react";
+import PropTypes from "prop-types";
 import OneSignal from "react-native-onesignal";
 import DeviceInfo from "react-native-device-info";
 import { connect } from "react-redux";

--- a/src/components/Arc.android.js
+++ b/src/components/Arc.android.js
@@ -1,5 +1,6 @@
-import React, { PropTypes, PureComponent } from "react";
+import React, { PureComponent } from "react";
 import { Image, Dimensions } from "react-native";
+import PropTypes from "prop-types";
 import styled from "styled-components/native";
 
 import Thumbnail from "./Thumbnail";

--- a/src/components/Arc.ios.js
+++ b/src/components/Arc.ios.js
@@ -1,5 +1,6 @@
-import React, { PropTypes, PureComponent } from "react";
+import React, { PureComponent } from "react";
 import { Image, Dimensions } from "react-native";
+import PropTypes from "prop-types";
 import ParallaxScrollView from "react-native-parallax-scroll-view";
 import styled from "styled-components/native";
 

--- a/src/components/Bookmark.js
+++ b/src/components/Bookmark.js
@@ -1,5 +1,6 @@
-import React, { PropTypes, PureComponent } from "react";
+import React, { PureComponent } from "react";
 import { Image, Platform } from "react-native";
+import PropTypes from "prop-types";
 import styled from "styled-components/native";
 
 import { images } from "../assets/";

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, PureComponent } from "react";
+import React, { PureComponent } from "react";
+import PropTypes from "prop-types";
 import Ionicons from "react-native-vector-icons/Ionicons";
 import styled from "styled-components/native";
 

--- a/src/components/ErrorBar.js
+++ b/src/components/ErrorBar.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, PureComponent } from "react";
+import React, { PureComponent } from "react";
+import PropTypes from "prop-types";
 import styled from "styled-components/native";
 import isError from "lodash/fp/isError";
 import get from "lodash/fp/get";

--- a/src/components/EventDate.js
+++ b/src/components/EventDate.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, PureComponent } from "react";
+import React, { PureComponent } from "react";
+import PropTypes from "prop-types";
 import moment from "moment";
 import trim from "lodash/trim";
 

--- a/src/components/ListViewRow.js
+++ b/src/components/ListViewRow.js
@@ -1,5 +1,6 @@
-import React, { PropTypes, PureComponent } from "react";
+import React, { PureComponent } from "react";
 import { Platform, StyleSheet } from "react-native";
+import PropTypes from "prop-types";
 import Ionicons from "react-native-vector-icons/Ionicons";
 import styled from "styled-components/native";
 import isArray from "lodash/fp/isArray";

--- a/src/components/ListViewRowAttendance.js
+++ b/src/components/ListViewRowAttendance.js
@@ -1,5 +1,6 @@
-import React, { PropTypes } from "react";
+import React from "react";
 import { Platform } from "react-native";
+import PropTypes from "prop-types";
 import styled from "styled-components/native";
 import get from "lodash/get";
 

--- a/src/components/ListViewRowBenefit.js
+++ b/src/components/ListViewRowBenefit.js
@@ -1,5 +1,6 @@
-import React, { PropTypes } from "react";
+import React from "react";
 import { Platform } from "react-native";
+import PropTypes from "prop-types";
 import styled from "styled-components/native";
 import moment from "moment";
 import get from "lodash/get";

--- a/src/components/ListViewRowDelegationship.js
+++ b/src/components/ListViewRowDelegationship.js
@@ -1,5 +1,6 @@
-import React, { PropTypes } from "react";
+import React from "react";
 import { Image, Platform } from "react-native";
+import PropTypes from "prop-types";
 import get from "lodash/get";
 import trimStart from "lodash/trimStart";
 

--- a/src/components/ListViewRowEvent.js
+++ b/src/components/ListViewRowEvent.js
@@ -1,5 +1,6 @@
-import React, { PropTypes } from "react";
+import React from "react";
 import { Platform } from "react-native";
+import PropTypes from "prop-types";
 import get from "lodash/get";
 
 import ListViewRow from "./ListViewRow";

--- a/src/components/ListViewRowInitiative.js
+++ b/src/components/ListViewRowInitiative.js
@@ -1,5 +1,6 @@
-import React, { PropTypes } from "react";
+import React from "react";
 import { Platform } from "react-native";
+import PropTypes from "prop-types";
 import get from "lodash/get";
 
 import ListViewRow from "./ListViewRow";

--- a/src/components/Logo.js
+++ b/src/components/Logo.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, PureComponent } from "react";
+import React, { PureComponent } from "react";
+import PropTypes from "prop-types";
 import styled from "styled-components/native";
 
 import { images } from "../assets";

--- a/src/components/MapView.js
+++ b/src/components/MapView.js
@@ -1,5 +1,6 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
 import { Dimensions, InteractionManager } from "react-native";
+import PropTypes from "prop-types";
 import MapView from "react-native-maps";
 import styled from "styled-components/native";
 

--- a/src/components/RichText.js
+++ b/src/components/RichText.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import Markdown from "react-native-simple-markdown";
 import styled from "styled-components/native";
 import has from "lodash/has";

--- a/src/components/SearchTag.js
+++ b/src/components/SearchTag.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, PureComponent } from "react";
+import React, { PureComponent } from "react";
+import PropTypes from "prop-types";
 import Ionicons from "react-native-vector-icons/Ionicons";
 import styled from "styled-components/native";
 

--- a/src/components/Social.js
+++ b/src/components/Social.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, PureComponent } from "react";
+import React, { PureComponent } from "react";
+import PropTypes from "prop-types";
 import EvilIcons from "react-native-vector-icons/EvilIcons";
 import styled from "styled-components/native";
 import socialUrl from "social-url";

--- a/src/components/TabBarIcon.js
+++ b/src/components/TabBarIcon.js
@@ -1,6 +1,7 @@
 /* eslint react/display-name: 0 */
 
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import styled from "styled-components/native";
 
 import { colors } from "../styles";

--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, PureComponent } from "react";
+import React, { PureComponent } from "react";
+import PropTypes from "prop-types";
 import styled from "styled-components/native";
 import isString from "lodash/isString";
 

--- a/src/components/Thumbnail.js
+++ b/src/components/Thumbnail.js
@@ -1,5 +1,6 @@
-import React, { PropTypes, PureComponent } from "react";
+import React, { PureComponent } from "react";
 import { View, Image, Platform } from "react-native";
+import PropTypes from "prop-types";
 import { BlurView } from "react-native-blur";
 import styled from "styled-components/native";
 

--- a/src/redux/Navigator.js
+++ b/src/redux/Navigator.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { addNavigationHelpers } from "react-navigation";
 import { connect } from "react-redux";
 import noop from "lodash/noop";

--- a/src/screens/About.js
+++ b/src/screens/About.js
@@ -1,5 +1,6 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
 import { Linking } from "react-native";
+import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import styled from "styled-components/native";
 import noop from "lodash/noop";

--- a/src/screens/Attendances.js
+++ b/src/screens/Attendances.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { denormalize } from "normalizr";
 import styled from "styled-components/native";

--- a/src/screens/Benefit.js
+++ b/src/screens/Benefit.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { denormalize } from "normalizr";
 import styled from "styled-components/native";

--- a/src/screens/BenefitActive.js
+++ b/src/screens/BenefitActive.js
@@ -1,4 +1,4 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
 import {
   Image,
   Platform,
@@ -7,6 +7,7 @@ import {
   Easing,
   findNodeHandle,
 } from "react-native";
+import PropTypes from "prop-types";
 import { BlurView } from "react-native-blur";
 import Spinner from "react-native-spinkit";
 import { connect } from "react-redux";

--- a/src/screens/Benefits.js
+++ b/src/screens/Benefits.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { denormalize } from "normalizr";
 import styled from "styled-components/native";

--- a/src/screens/BenefitsSaved.js
+++ b/src/screens/BenefitsSaved.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { denormalize } from "normalizr";
 import styled from "styled-components/native";

--- a/src/screens/Delegationship.js
+++ b/src/screens/Delegationship.js
@@ -1,5 +1,6 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
 import { Linking } from "react-native";
+import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { denormalize } from "normalizr";
 import styled from "styled-components/native";

--- a/src/screens/Delegationships.js
+++ b/src/screens/Delegationships.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { denormalize } from "normalizr";
 import styled from "styled-components/native";

--- a/src/screens/Event.js
+++ b/src/screens/Event.js
@@ -1,4 +1,4 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
 import {
   StyleSheet,
   Image,
@@ -7,6 +7,7 @@ import {
   Dimensions,
   Platform,
 } from "react-native";
+import PropTypes from "prop-types";
 import ParallaxScrollView from "react-native-parallax-scroll-view";
 import { Svg as SVG, Polygon } from "react-native-svg";
 import { connect } from "react-redux";

--- a/src/screens/Events.js
+++ b/src/screens/Events.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { denormalize } from "normalizr";
 import styled from "styled-components/native";

--- a/src/screens/EventsSaved.js
+++ b/src/screens/EventsSaved.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { denormalize } from "normalizr";
 import styled from "styled-components/native";

--- a/src/screens/EventsToday.js
+++ b/src/screens/EventsToday.js
@@ -1,5 +1,6 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
 import { ListView, Dimensions, findNodeHandle } from "react-native";
+import PropTypes from "prop-types";
 import { BlurView } from "react-native-blur";
 import Ionicons from "react-native-vector-icons/Ionicons";
 import { connect } from "react-redux";

--- a/src/screens/Initiative.js
+++ b/src/screens/Initiative.js
@@ -1,5 +1,6 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
 import { Linking } from "react-native";
+import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { denormalize } from "normalizr";
 import styled from "styled-components/native";

--- a/src/screens/Initiatives.js
+++ b/src/screens/Initiatives.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { denormalize } from "normalizr";
 import styled from "styled-components/native";

--- a/src/screens/SearchView.js
+++ b/src/screens/SearchView.js
@@ -1,5 +1,6 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
 import { StyleSheet, ListView, Dimensions } from "react-native";
+import PropTypes from "prop-types";
 import LinearGradient from "react-native-linear-gradient";
 import Ionicons from "react-native-vector-icons/Ionicons";
 import { connect } from "react-redux";

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -1,5 +1,6 @@
-import React, { PropTypes } from "react";
+import React from "react";
 import { StatusBar } from "react-native";
+import PropTypes from "prop-types";
 import styled, { ThemeProvider } from "styled-components/native";
 import isArray from "lodash/fp/isArray";
 


### PR DESCRIPTION
* From 15.5 proptypes are located in a separate package: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes